### PR TITLE
Fix import problem (it imported ctarget from opinions)

### DIFF
--- a/multisieve_coreference/dump.py
+++ b/multisieve_coreference/dump.py
@@ -1,7 +1,7 @@
 import logging
 
-from KafNafParserPy import Cspan, Ctarget, Ccoreference
-
+from KafNafParserPy.span_data import Cspan, Ctarget
+from KafNafParserPy.coreference_data import  Ccoreference
 
 logger = logging.getLogger(None if __name__ == '__main__' else __name__)
 


### PR DESCRIPTION
It gave an error because it imported ctarget from opinion_data rather than span_data due to the order of imports in `KafNafParserPy/__init__.py`